### PR TITLE
chore: remove `tsc` command when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "nodemon",
     "format": "prettier -w .",
-    "lint": "tsc && eslint --fix .",
+    "lint": "eslint --fix .",
     "start": "cross-env NODE_ENV=production node --loader @esbuild-kit/esm-loader src/index.ts",
     "sync": "node --loader @esbuild-kit/esm-loader tools/copy-config.ts",
     "typecheck": "tsc"


### PR DESCRIPTION
There is already a type checking process when running eslint, this reduces redundant time duration for duplicated checking